### PR TITLE
fix parseInt2 expected number

### DIFF
--- a/gsmlib/gsm_parser.cc
+++ b/gsmlib/gsm_parser.cc
@@ -50,8 +50,8 @@ bool Parser::checkEmptyParameter(bool allowNoParameter) throw(GsmException)
       else
 	throwParseException(_("expected parameter"));
 
-      putBackChar();
     }
+  putBackChar();
   return false;
 }
 


### PR DESCRIPTION
checkEmptyParameter has read first number and didn't put them back.
parseInt2 reads ',' and complains about missing number. In Addition line 53 isn't reachable.

input: 0,1,1,1
checkEmptyParameter reads '0'
parseInt2 reads ','
